### PR TITLE
Make download endpoint more ergonomic

### DIFF
--- a/examples/download.py
+++ b/examples/download.py
@@ -1,5 +1,4 @@
 import datetime
-import sys
 from datetime import datetime, timedelta
 
 from foxglove_data_platform.client import Client
@@ -8,15 +7,11 @@ token = "<YOUR API TOKEN HERE>"
 device_id = "<YOUR DEVICE ID>"
 client = Client(token=token)
 
-download_stream = client.download_data(
+data = client.download_data(
     device_id=device_id,
     start=datetime.now() - timedelta(hours=3),
     end=datetime.now() - timedelta(hours=1),
+    callback=lambda progress: print(".", end=""),
 )
 
-data = bytes()
-for chunk in download_stream.iter_content(chunk_size=64 * 1024):
-    sys.stdout.write(".")
-    data += chunk
-
-print("download", len(data))
+print(f"downloaded {len(data)} bytes")

--- a/examples/events.py
+++ b/examples/events.py
@@ -14,5 +14,5 @@ event = client.create_event(
 )
 print(event)
 
-events = client.list_events()
+events = client.get_events()
 print(events)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.0.12
+version = 0.0.13
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,7 +27,7 @@ def test_get_events():
         ],
     )
     client = Client("test")
-    events = client.list_events(device_id=device_id)
+    events = client.get_events(device_id=device_id)
     assert len(events) == 1
     assert events[0]["device_id"] == device_id
 
@@ -67,12 +67,9 @@ def test_download():
     data = fake.binary(4096)
     responses.add(responses.GET, download_link, body=data)
     client = Client("test")
-    download_response = client.download_data(
+    response_data = client.download_data(
         device_id="test_id", start=datetime.now(), end=datetime.now()
     )
-    response_data = bytes()
-    for chunk in download_response.iter_content():
-        response_data += chunk
     assert data == response_data
 
 


### PR DESCRIPTION
**Public-Facing Changes**
This makes the `download_data` function more ergonomic.


**Description**
Now it will just return the data directly instead of requiring the user to assemble the chunked responses. It now allows a `callback` parameter to monitor the progress of the download.

<!-- link relevant GitHub issues -->
