### PR TITLE
Fix typing_extensions bug

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -2,7 +2,8 @@ import datetime
 import os
 from enum import Enum
 from io import BytesIO
-from typing import IO, Any, Dict, List, Optional, Protocol, Union
+from typing import IO, Any, Dict, List, Optional, Union
+from typing_extensions import Protocol
 
 import arrow
 import requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.0.14
+version = 0.0.15
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
**Public-Facing Changes**
Fix missing `Protocol` type error by importing from `typing_extensions`.

<!-- link relevant GitHub issues -->
