### PR TITLE
Add tests & format json for topics & coverage endpoints

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -281,7 +281,14 @@ class Client:
             },
         )
         response.raise_for_status()
-        return response.json()
+        return [
+            {
+                "device_id": c["deviceId"],
+                "start": arrow.get(c["start"]).datetime,
+                "end": arrow.get(c["end"]).datetime,
+            }
+            for c in response.json()
+        ]
 
     def get_devices(self):
         response = requests.get(
@@ -328,7 +335,6 @@ class Client:
         device_id: str,
         start: datetime.datetime,
         end: datetime.datetime,
-        include_schemas: Optional[bool] = False,
     ):
         response = requests.get(
             self.__url__("/v1/data/topics"),
@@ -337,12 +343,20 @@ class Client:
                 "deviceId": device_id,
                 "start": start.astimezone().isoformat(),
                 "end": end.astimezone().isoformat(),
-                "includeSchemas": include_schemas,
+                "includeSchemas": "false",
             },
         )
-        print(to_curl(response.request))
         response.raise_for_status()
-        return response.json()
+        return [
+            {
+                "topic": t["topic"],
+                "version": t["version"],
+                "encoding": t["encoding"],
+                "schema_encoding": t["schemaEncoding"],
+                "schema_name": t["schemaName"],
+            }
+            for t in response.json()
+        ]
 
     def upload_data(
         self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.0.16
+version = 0.0.17
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,27 +9,41 @@ fake = Faker()
 
 
 @responses.activate
-def test_get_events():
-    device_id = "my_device_id"
+def test_download():
+    download_link = fake.url()
+    responses.add(
+        responses.POST,
+        "https://api.foxglove.dev/v1/data/stream",
+        json={
+            "link": download_link,
+        },
+    )
+    data = fake.binary(4096)
+    responses.add(responses.GET, download_link, body=data)
+    client = Client("test")
+    response_data = client.download_data(
+        device_id="test_id", start=datetime.now(), end=datetime.now()
+    )
+    assert data == response_data
+
+
+@responses.activate
+def test_get_coverage():
     responses.add(
         responses.GET,
-        f"https://api.foxglove.dev/beta/device-events?deviceId={device_id}",
+        "https://api.foxglove.dev/v1/data/coverage",
         json=[
             {
-                "id": "1",
-                "createdAt": datetime.now().isoformat(),
-                "deviceId": device_id,
-                "durationNanos": fake.pyint(),
-                "metadata": {},
-                "timestampNanos": fake.pyint(),
-                "updatedAt": datetime.now().isoformat(),
+                "deviceId": "device_id",
+                "start": datetime.now().isoformat(),
+                "end": datetime.now().isoformat(),
             }
         ],
     )
     client = Client("test")
-    events = client.get_events(device_id=device_id)
-    assert len(events) == 1
-    assert events[0]["device_id"] == device_id
+    coverage_response = client.get_coverage(start=datetime.now(), end=datetime.now())
+    assert len(coverage_response) == 1
+    assert coverage_response[0]["device_id"] == "device_id"
 
 
 @responses.activate
@@ -55,41 +69,50 @@ def test_get_devices():
 
 
 @responses.activate
-def test_download():
-    download_link = fake.url()
+def test_get_events():
+    device_id = "my_device_id"
     responses.add(
-        responses.POST,
-        "https://api.foxglove.dev/v1/data/stream",
-        json={
-            "link": download_link,
-        },
+        responses.GET,
+        f"https://api.foxglove.dev/beta/device-events?deviceId={device_id}",
+        json=[
+            {
+                "id": "1",
+                "createdAt": datetime.now().isoformat(),
+                "deviceId": device_id,
+                "durationNanos": fake.pyint(),
+                "metadata": {},
+                "timestampNanos": fake.pyint(),
+                "updatedAt": datetime.now().isoformat(),
+            }
+        ],
     )
-    data = fake.binary(4096)
-    responses.add(responses.GET, download_link, body=data)
     client = Client("test")
-    response_data = client.download_data(
-        device_id="test_id", start=datetime.now(), end=datetime.now()
-    )
-    assert data == response_data
+    events = client.get_events(device_id=device_id)
+    assert len(events) == 1
+    assert events[0]["device_id"] == device_id
 
 
 @responses.activate
-def test_upload():
-    upload_link = fake.url()
+def test_get_topics():
     responses.add(
-        responses.POST,
-        "https://api.foxglove.dev/v1/data/upload",
-        json={
-            "link": upload_link,
-        },
+        responses.GET,
+        "https://api.foxglove.dev/v1/data/topics",
+        json=[
+            {
+                "topic": "/topic",
+                "version": "1",
+                "encoding": "ros1",
+                "schemaEncoding": "ros1msg",
+                "schemaName": "std_msgs/String",
+            }
+        ],
     )
-    responses.add(responses.PUT, upload_link)
     client = Client("test")
-    data = fake.binary(4096)
-    upload_response = client.upload_data(
-        device_id="test_device_id", filename="test_file.mcap", data=data
+    topics_response = client.get_topics(
+        device_id="device", start=datetime.now(), end=datetime.now()
     )
-    assert upload_response["link"] == upload_link
+    assert len(topics_response) == 1
+    assert topics_response[0]["topic"] == "/topic"
 
 
 @responses.activate
@@ -113,5 +136,24 @@ def test_streaming_upload():
         filename="test_file.mcap",
         data=file,
         callback=lambda size, progress: print(".", end=""),
+    )
+    assert upload_response["link"] == upload_link
+
+
+@responses.activate
+def test_upload():
+    upload_link = fake.url()
+    responses.add(
+        responses.POST,
+        "https://api.foxglove.dev/v1/data/upload",
+        json={
+            "link": upload_link,
+        },
+    )
+    responses.add(responses.PUT, upload_link)
+    client = Client("test")
+    data = fake.binary(4096)
+    upload_response = client.upload_data(
+        device_id="test_device_id", filename="test_file.mcap", data=data
     )
     assert upload_response["link"] == upload_link


### PR DESCRIPTION
**Public-Facing Changes**
Parse json for `/coverage` and `/topics` endpoints and add tests.

<!-- link relevant GitHub issues -->
