### PR TITLE
Support deleting events and fetching individual devices

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -562,11 +562,11 @@
         },
         "pyright": {
             "hashes": [
-                "sha256:08d893a3404abce5efcaf78824c6a40df6f008b90b6c576d39dd79664736f0e1",
-                "sha256:2c79e532815f89e8d4fa931b105840c1f2838431bfad457c5b3d34b1ad3cba47"
+                "sha256:74c57fb5e37cc39e6695bf51136dc6ee387f64242b0a4b70cb5694670ed5a73c",
+                "sha256:c7d4b6633aaad00cf734264c2afc0dffa60db4760068888e1fd0ab1bed9b7455"
             ],
             "index": "pypi",
-            "version": "==1.1.232"
+            "version": "==1.1.233"
         },
         "pytest": {
             "hashes": [

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -339,7 +339,31 @@ class Client:
             for c in json
         ]
 
+    def get_device(self, device_id: str):
+        """
+        Gets a single device by id.
+
+        :param device_id: The id of the device to retrieve.
+        """
+        response = requests.get(
+            self.__url__(f"/v1/devices/{device_id}"),
+            headers=self.__headers,
+        )
+
+        device = json_or_raise(response)
+
+        return {
+            "id": device["id"],
+            "name": device["name"],
+            "serial_number": device["serialNumber"],
+            "created_at": arrow.get(device["createdAt"]).datetime,
+            "updated_at": arrow.get(device["updatedAt"]).datetime,
+        }
+
     def get_devices(self):
+        """
+        Returns a list of all devices.
+        """
         response = requests.get(
             self.__url__("/v1/devices"),
             headers=self.__headers,

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -148,7 +148,31 @@ class Client:
             },
         )
 
-        return json_or_raise(response)
+        event = json_or_raise(response)
+        return {
+            "id": event["id"],
+            "device_id": event["deviceId"],
+            "timestamp_nanos": event["timestampNanos"],
+            "duration_nanos": event["durationNanos"],
+            "metadata": event["metadata"],
+            "created_at": arrow.get(event["createdAt"]).datetime,
+            "updated_at": arrow.get(event["updatedAt"]).datetime,
+        }
+
+    def delete_event(
+        self,
+        event_id: str,
+    ):
+        """
+        Deletes an event.
+
+        event_id: The id of the event to delete.
+        """
+        request = requests.delete(
+            self.__url__(f"/beta/device-events/{event_id}"),
+            headers=self.__headers,
+        )
+        request.raise_for_status()
 
     def get_events(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime
 from tempfile import TemporaryFile
 
@@ -102,6 +103,43 @@ def test_get_devices():
     devices = client.get_devices()
     assert len(devices) == 1
     assert devices[0]["id"] == id
+
+
+@responses.activate
+def test_create_event():
+    id = fake.uuid4()
+    device_id = fake.uuid4()
+    responses.add(
+        responses.POST,
+        "https://api.foxglove.dev/beta/device-events",
+        json={
+            "id": id,
+            "deviceId": device_id,
+            "timestampNanos": str(time.time_ns()),
+            "durationNanos": "1",
+            "metadata": {"foo": "bar"},
+            "createdAt": datetime.now().isoformat(),
+            "updatedAt": datetime.now().isoformat(),
+        },
+    )
+    client = Client("test")
+    event = client.create_event(device_id=device_id, time=datetime.now(), duration=1)
+    assert event["id"] == id
+    assert event["device_id"] == device_id
+
+
+@responses.activate
+def test_delete_event():
+    id = fake.uuid4()
+    responses.add(
+        responses.DELETE,
+        f"https://api.foxglove.dev/beta/device-events/{id}",
+    )
+    client = Client("test")
+    try:
+        client.delete_event(event_id=id)
+    except:
+        assert False
 
 
 @responses.activate

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,6 +84,25 @@ def test_create_device():
 
 
 @responses.activate
+def test_get_device():
+    id = fake.uuid4()
+    responses.add(
+        responses.GET,
+        f"https://api.foxglove.dev/v1/devices/{id}",
+        json={
+            "id": id,
+            "name": fake.sentence(2),
+            "serialNumber": fake.pyint(),
+            "createdAt": datetime.now().isoformat(),
+            "updatedAt": datetime.now().isoformat(),
+        },
+    )
+    client = Client("test")
+    device = client.get_device(device_id=id)
+    assert device["id"] == id
+
+
+@responses.activate
 def test_get_devices():
     id = fake.uuid4()
     responses.add(


### PR DESCRIPTION
**Public-Facing Changes**
This adds client calls for deleting events and for fetching single devices by id.

Fixes #22
Fixes #18 