### PR TITLE
Breakup tests and add delete import call

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -409,6 +409,20 @@ class Client:
             "serial_number": device["serialNumber"],
         }
 
+    def delete_import(self, device_id: str, import_id: str):
+        """
+        Deletes an existing import.
+
+        :param device_id: The id of the device associated with the import.
+        :param import_id: The id of the import to delete.
+        """
+        request = requests.delete(
+            self.__url__(f"/v1/data/imports/{import_id}"),
+            params={"deviceId": device_id},
+            headers=self.__headers,
+        )
+        request.raise_for_status()
+
     def get_imports(self):
         response = requests.get(
             self.__url__("/v1/data/imports"),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.0.19
+version = 0.1.0
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/api_url.py
+++ b/tests/api_url.py
@@ -1,0 +1,2 @@
+def api_url(path: str):
+    return "https://api.foxglove.dev" + path

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,12 +1,12 @@
-import time
 from datetime import datetime
-from tempfile import TemporaryFile
 
 import pytest
 import responses
 from faker import Faker
 from foxglove_data_platform.client import Client
 from requests.exceptions import RequestException
+
+from .api_url import api_url
 
 fake = Faker()
 
@@ -16,7 +16,7 @@ def test_error_reason():
     reason = fake.text()
     responses.add(
         responses.GET,
-        "https://api.foxglove.dev/v1/data/coverage",
+        api_url("/v1/data/coverage"),
         status=403,
         json={"error": reason},
     )
@@ -27,29 +27,10 @@ def test_error_reason():
 
 
 @responses.activate
-def test_download():
-    download_link = fake.url()
-    responses.add(
-        responses.POST,
-        "https://api.foxglove.dev/v1/data/stream",
-        json={
-            "link": download_link,
-        },
-    )
-    data = fake.binary(4096)
-    responses.add(responses.GET, download_link, body=data)
-    client = Client("test")
-    response_data = client.download_data(
-        device_id="test_id", start=datetime.now(), end=datetime.now()
-    )
-    assert data == response_data
-
-
-@responses.activate
 def test_get_coverage():
     responses.add(
         responses.GET,
-        "https://api.foxglove.dev/v1/data/coverage",
+        api_url("/v1/data/coverage"),
         json=[
             {
                 "deviceId": "device_id",
@@ -65,131 +46,10 @@ def test_get_coverage():
 
 
 @responses.activate
-def test_create_device():
-    id = fake.uuid4()
-    name = "name"
-    serial_number = "serial"
-    responses.add(
-        responses.POST,
-        "https://api.foxglove.dev/v1/devices",
-        json={
-            "id": id,
-            "name": name,
-            "serialNumber": serial_number,
-        },
-    )
-    client = Client("test")
-    device = client.create_device(name=name, serial_number=serial_number)
-    assert device["serial_number"] == serial_number
-
-
-@responses.activate
-def test_get_device():
-    id = fake.uuid4()
-    responses.add(
-        responses.GET,
-        f"https://api.foxglove.dev/v1/devices/{id}",
-        json={
-            "id": id,
-            "name": fake.sentence(2),
-            "serialNumber": fake.pyint(),
-            "createdAt": datetime.now().isoformat(),
-            "updatedAt": datetime.now().isoformat(),
-        },
-    )
-    client = Client("test")
-    device = client.get_device(device_id=id)
-    assert device["id"] == id
-
-
-@responses.activate
-def test_get_devices():
-    id = fake.uuid4()
-    responses.add(
-        responses.GET,
-        "https://api.foxglove.dev/v1/devices",
-        json=[
-            {
-                "id": id,
-                "name": fake.sentence(2),
-                "serialNumber": fake.pyint(),
-                "createdAt": datetime.now().isoformat(),
-                "updatedAt": datetime.now().isoformat(),
-            }
-        ],
-    )
-    client = Client("test")
-    devices = client.get_devices()
-    assert len(devices) == 1
-    assert devices[0]["id"] == id
-
-
-@responses.activate
-def test_create_event():
-    id = fake.uuid4()
-    device_id = fake.uuid4()
-    responses.add(
-        responses.POST,
-        "https://api.foxglove.dev/beta/device-events",
-        json={
-            "id": id,
-            "deviceId": device_id,
-            "timestampNanos": str(time.time_ns()),
-            "durationNanos": "1",
-            "metadata": {"foo": "bar"},
-            "createdAt": datetime.now().isoformat(),
-            "updatedAt": datetime.now().isoformat(),
-        },
-    )
-    client = Client("test")
-    event = client.create_event(device_id=device_id, time=datetime.now(), duration=1)
-    assert event["id"] == id
-    assert event["device_id"] == device_id
-
-
-@responses.activate
-def test_delete_event():
-    id = fake.uuid4()
-    responses.add(
-        responses.DELETE,
-        f"https://api.foxglove.dev/beta/device-events/{id}",
-    )
-    client = Client("test")
-    try:
-        client.delete_event(event_id=id)
-    except:
-        assert False
-
-
-@responses.activate
-def test_get_events():
-    device_id = "my_device_id"
-    responses.add(
-        responses.GET,
-        f"https://api.foxglove.dev/beta/device-events?deviceId={device_id}",
-        json=[
-            {
-                "id": "1",
-                "createdAt": datetime.now().isoformat(),
-                "deviceId": device_id,
-                "durationNanos": fake.pyint(),
-                "metadata": {},
-                "timestampNanos": fake.pyint(),
-                "updatedAt": datetime.now().isoformat(),
-            }
-        ],
-    )
-    client = Client("test")
-    events = client.get_events(device_id=device_id)
-    assert len(events) == 1
-    assert events[0]["device_id"] == device_id
-
-
-@responses.activate
 def test_get_topics():
     responses.add(
         responses.GET,
-        "https://api.foxglove.dev/v1/data/topics",
+        api_url("/v1/data/topics"),
         json=[
             {
                 "topic": "/topic",
@@ -206,47 +66,3 @@ def test_get_topics():
     )
     assert len(topics_response) == 1
     assert topics_response[0]["topic"] == "/topic"
-
-
-@responses.activate
-def test_streaming_upload():
-    upload_link = fake.url()
-    responses.add(
-        responses.POST,
-        "https://api.foxglove.dev/v1/data/upload",
-        json={
-            "link": upload_link,
-        },
-    )
-    responses.add(responses.PUT, upload_link)
-    client = Client("test")
-    data = fake.binary(4096)
-    file = TemporaryFile()
-    file.write(data)
-    file.seek(0)
-    upload_response = client.upload_data(
-        device_id="test_device_id",
-        filename="test_file.mcap",
-        data=file,
-        callback=lambda size, progress: print(".", end=""),
-    )
-    assert upload_response["link"] == upload_link
-
-
-@responses.activate
-def test_upload():
-    upload_link = fake.url()
-    responses.add(
-        responses.POST,
-        "https://api.foxglove.dev/v1/data/upload",
-        json={
-            "link": upload_link,
-        },
-    )
-    responses.add(responses.PUT, upload_link)
-    client = Client("test")
-    data = fake.binary(4096)
-    upload_response = client.upload_data(
-        device_id="test_device_id", filename="test_file.mcap", data=data
-    )
-    assert upload_response["link"] == upload_link

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+from tempfile import TemporaryFile
+
+import responses
+from faker import Faker
+from foxglove_data_platform.client import Client
+
+from .api_url import api_url
+
+fake = Faker()
+
+
+@responses.activate
+def test_delete_import():
+    device_id = fake.uuid4()
+    import_id = fake.uuid4()
+    responses.add(
+        responses.DELETE,
+        api_url(f"/v1/data/imports/{import_id}?deviceId={device_id}"),
+    )
+    try:
+        client = Client("test")
+        client.delete_import(device_id=device_id, import_id=import_id)
+    except:
+        assert False
+
+
+@responses.activate
+def test_download():
+    download_link = fake.url()
+    responses.add(
+        responses.POST,
+        api_url("/v1/data/stream"),
+        json={
+            "link": download_link,
+        },
+    )
+    data = fake.binary(4096)
+    responses.add(responses.GET, download_link, body=data)
+    client = Client("test")
+    response_data = client.download_data(
+        device_id="test_id", start=datetime.now(), end=datetime.now()
+    )
+    assert data == response_data
+
+
+@responses.activate
+def test_streaming_upload():
+    upload_link = fake.url()
+    responses.add(
+        responses.POST,
+        api_url("/v1/data/upload"),
+        json={
+            "link": upload_link,
+        },
+    )
+    responses.add(responses.PUT, upload_link)
+    client = Client("test")
+    data = fake.binary(4096)
+    file = TemporaryFile()
+    file.write(data)
+    file.seek(0)
+    upload_response = client.upload_data(
+        device_id="test_device_id",
+        filename="test_file.mcap",
+        data=file,
+        callback=lambda size, progress: print(".", end=""),
+    )
+    assert upload_response["link"] == upload_link
+
+
+@responses.activate
+def test_upload():
+    upload_link = fake.url()
+    responses.add(
+        responses.POST,
+        api_url("/v1/data/upload"),
+        json={
+            "link": upload_link,
+        },
+    )
+    responses.add(responses.PUT, upload_link)
+    client = Client("test")
+    data = fake.binary(4096)
+    upload_response = client.upload_data(
+        device_id="test_device_id", filename="test_file.mcap", data=data
+    )
+    assert upload_response["link"] == upload_link

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+
+import responses
+from faker import Faker
+from foxglove_data_platform.client import Client
+
+from .api_url import api_url
+
+fake = Faker()
+
+
+@responses.activate
+def test_create_device():
+    id = fake.uuid4()
+    name = "name"
+    serial_number = "serial"
+    responses.add(
+        responses.POST,
+        api_url("/v1/devices"),
+        json={
+            "id": id,
+            "name": name,
+            "serialNumber": serial_number,
+        },
+    )
+    client = Client("test")
+    device = client.create_device(name=name, serial_number=serial_number)
+    assert device["serial_number"] == serial_number
+
+
+@responses.activate
+def test_get_device():
+    id = fake.uuid4()
+    responses.add(
+        responses.GET,
+        api_url(f"/v1/devices/{id}"),
+        json={
+            "id": id,
+            "name": fake.sentence(2),
+            "serialNumber": fake.pyint(),
+            "createdAt": datetime.now().isoformat(),
+            "updatedAt": datetime.now().isoformat(),
+        },
+    )
+    client = Client("test")
+    device = client.get_device(device_id=id)
+    assert device["id"] == id
+
+
+@responses.activate
+def test_get_devices():
+    id = fake.uuid4()
+    responses.add(
+        responses.GET,
+        api_url("/v1/devices"),
+        json=[
+            {
+                "id": id,
+                "name": fake.sentence(2),
+                "serialNumber": fake.pyint(),
+                "createdAt": datetime.now().isoformat(),
+                "updatedAt": datetime.now().isoformat(),
+            }
+        ],
+    )
+    client = Client("test")
+    devices = client.get_devices()
+    assert len(devices) == 1
+    assert devices[0]["id"] == id

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,71 @@
+import time
+from datetime import datetime
+
+import responses
+from faker import Faker
+from foxglove_data_platform.client import Client
+
+from .api_url import api_url
+
+fake = Faker()
+
+
+@responses.activate
+def test_create_event():
+    id = fake.uuid4()
+    device_id = fake.uuid4()
+    responses.add(
+        responses.POST,
+        api_url("/beta/device-events"),
+        json={
+            "id": id,
+            "deviceId": device_id,
+            "timestampNanos": str(time.time_ns()),
+            "durationNanos": "1",
+            "metadata": {"foo": "bar"},
+            "createdAt": datetime.now().isoformat(),
+            "updatedAt": datetime.now().isoformat(),
+        },
+    )
+    client = Client("test")
+    event = client.create_event(device_id=device_id, time=datetime.now(), duration=1)
+    assert event["id"] == id
+    assert event["device_id"] == device_id
+
+
+@responses.activate
+def test_delete_event():
+    id = fake.uuid4()
+    responses.add(
+        responses.DELETE,
+        api_url(f"/beta/device-events/{id}"),
+    )
+    client = Client("test")
+    try:
+        client.delete_event(event_id=id)
+    except:
+        assert False
+
+
+@responses.activate
+def test_get_events():
+    device_id = "my_device_id"
+    responses.add(
+        responses.GET,
+        api_url(f"/beta/device-events?deviceId={device_id}"),
+        json=[
+            {
+                "id": "1",
+                "createdAt": datetime.now().isoformat(),
+                "deviceId": device_id,
+                "durationNanos": fake.pyint(),
+                "metadata": {},
+                "timestampNanos": fake.pyint(),
+                "updatedAt": datetime.now().isoformat(),
+            }
+        ],
+    )
+    client = Client("test")
+    events = client.get_events(device_id=device_id)
+    assert len(events) == 1
+    assert events[0]["device_id"] == device_id


### PR DESCRIPTION
**Public-Facing Changes**
This adds a `delete_import` method for deleting existing imports and also breaks up the client test into resource-specific test files.
