### PR TITLE
Require typing_extensions library

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.1.0
+version = 0.1.1
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -15,6 +15,7 @@ include_package_data = True
 install_requires =
     arrow
     requests
+    typing_extensions
 packages = find:
 python_requires = >=3.7
 


### PR DESCRIPTION
**Public-Facing Changes**
This updates the setup.cfg dependencies to include the `typing_extensions` library needed by Python 3.7.

<!-- link relevant GitHub issues -->
Fixes #28 