### PR TITLE
Camelize sortBy values in request

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -43,6 +43,16 @@ def decoder_for_schema(schema: Any):
         return ProtobufDecoder
 
 
+def camelize(snake_name: Optional[str]) -> Optional[str]:
+    """
+    Convert a valid snake_case field name to camelCase for the API
+    """
+    if not snake_name:
+        return snake_name
+    parts = snake_name.split("_")
+    return "".join([parts[0]] + [w.title() for w in parts[1:]])
+
+
 class FoxgloveException(Exception):
     pass
 
@@ -193,7 +203,7 @@ class Client:
         device_id: Id of the device associated with the events.
         device_name: Name of the device associated with events.
             Either device_id or device_name is required.
-        sort_by: Optionally sort records by this field name.
+        sort_by: Optionally sort records by this field name (e.g. "device_id").
         sort_order: Optionally specify the sort order, either "asc" or "desc".
         limit: Optionally limit the number of records return.
         offset: Optionally offset the results by this many records.
@@ -208,7 +218,7 @@ class Client:
         params = {
             "deviceId": device_id,
             "deviceName": device_name,
-            "sortBy": sort_by,
+            "sortBy": camelize(sort_by),
             "sortOrder": sort_order,
             "limit": limit,
             "offset": offset,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.1.3
+version = 0.1.4
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 import responses
 from faker import Faker
-from foxglove_data_platform.client import Client
+from foxglove_data_platform.client import Client, camelize
 from requests.exceptions import RequestException
 
 from .api_url import api_url
@@ -66,3 +66,9 @@ def test_get_topics():
     )
     assert len(topics_response) == 1
     assert topics_response[0]["topic"] == "/topic"
+
+
+def test_camelize():
+    assert camelize("a_field_name") == "aFieldName"
+    assert camelize("aFieldName") == "aFieldName"
+    assert camelize(None) is None


### PR DESCRIPTION
**Public-Facing Changes**

Allows clients to pass snake_case names for the `sortBy` arg. This can be used in additional endpoints in the future.

**Description**

Docs discussion: https://github.com/foxglove/website/pull/424#discussion_r844501114