### PR TITLE
client: allow user to point at custom API host

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -123,15 +123,16 @@ def json_or_raise(response: requests.Response):
 
 
 class Client:
-    def __init__(self, token: str):
+    def __init__(self, token: str, host: str = "api.foxglove.dev"):
         self.__token = token
         self.__headers = {
             "Content-type": "application/json",
             "Authorization": "Bearer " + self.__token,
         }
+        self.__host = host
 
     def __url__(self, path: str):
-        return f"https://api.foxglove.dev{path}"
+        return f"https://{self.__host}{path}"
 
     def create_event(
         self,


### PR DESCRIPTION
**Public-Facing Changes**
`Client` takes an optional `host=` constructor argument, to point it towards a different API service host.

**Description**
Allow the user to point at a different API host, for testing against non-production instances of the API service.

<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
