### PR TITLE
client: speed up download_data using BytesIO

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -339,12 +339,12 @@ class Client:
 
         link = json["link"]
         response = requests.get(link, stream=True)
-        data = bytes()
+        data = BytesIO()
         for chunk in response.iter_content(chunk_size=32 * 1024):
-            data += chunk
+            data.write(chunk)
             if callback:
-                callback(progress=len(data))
-        return data
+                callback(progress=data.tell())
+        return data.getvalue()
 
     def get_coverage(
         self,


### PR DESCRIPTION
`bytes` is immutable, so the operation `data += chunk` creates a new object and copies the old data into it along with the new data. This is inefficient, and throttles download speed, especially after a significant number of bytes have already been downloaded. Anecdotally, I saw my download speed dip down to 800Kb/s before I went looking for this bug.

This PR replaces its usage with `BytesIO`, which is a mutable byte buffer with efficient appends via write(). After making this change I saw my download speed limited by my network bandwidth rather than CPU.