### PR TITLE
client: add parameter to get_messages to specify decoders explicitly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ install_requires =
     arrow
     requests
     typing_extensions
+    mcap
 packages = find:
 python_requires = >=3.7
 

--- a/tests/string_message_pb2.py
+++ b/tests/string_message_pb2.py
@@ -7,28 +7,32 @@ from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
 
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
+    b'\n\x14string_message.proto"\x1d\n\rStringMessage\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\tb\x06proto3'
+)
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14string_message.proto\"\x1d\n\rStringMessage\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\tb\x06proto3')
-
-
-
-_STRINGMESSAGE = DESCRIPTOR.message_types_by_name['StringMessage']
-StringMessage = _reflection.GeneratedProtocolMessageType('StringMessage', (_message.Message,), {
-  'DESCRIPTOR' : _STRINGMESSAGE,
-  '__module__' : 'string_message_pb2'
-  # @@protoc_insertion_point(class_scope:StringMessage)
-  })
+_STRINGMESSAGE = DESCRIPTOR.message_types_by_name["StringMessage"]
+StringMessage = _reflection.GeneratedProtocolMessageType(
+    "StringMessage",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _STRINGMESSAGE,
+        "__module__": "string_message_pb2"
+        # @@protoc_insertion_point(class_scope:StringMessage)
+    },
+)
 _sym_db.RegisterMessage(StringMessage)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
 
-  DESCRIPTOR._options = None
-  _STRINGMESSAGE._serialized_start=24
-  _STRINGMESSAGE._serialized_end=53
+    DESCRIPTOR._options = None
+    _STRINGMESSAGE._serialized_start = 24
+    _STRINGMESSAGE._serialized_end = 53
 # @@protoc_insertion_point(module_scope)

--- a/tests/string_message_pb2.py
+++ b/tests/string_message_pb2.py
@@ -7,32 +7,28 @@ from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x14string_message.proto"\x1d\n\rStringMessage\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\tb\x06proto3'
-)
 
 
-_STRINGMESSAGE = DESCRIPTOR.message_types_by_name["StringMessage"]
-StringMessage = _reflection.GeneratedProtocolMessageType(
-    "StringMessage",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _STRINGMESSAGE,
-        "__module__": "string_message_pb2"
-        # @@protoc_insertion_point(class_scope:StringMessage)
-    },
-)
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14string_message.proto\"\x1d\n\rStringMessage\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\tb\x06proto3')
+
+
+
+_STRINGMESSAGE = DESCRIPTOR.message_types_by_name['StringMessage']
+StringMessage = _reflection.GeneratedProtocolMessageType('StringMessage', (_message.Message,), {
+  'DESCRIPTOR' : _STRINGMESSAGE,
+  '__module__' : 'string_message_pb2'
+  # @@protoc_insertion_point(class_scope:StringMessage)
+  })
 _sym_db.RegisterMessage(StringMessage)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
 
-    DESCRIPTOR._options = None
-    _STRINGMESSAGE._serialized_start = 24
-    _STRINGMESSAGE._serialized_end = 53
+  DESCRIPTOR._options = None
+  _STRINGMESSAGE._serialized_start=24
+  _STRINGMESSAGE._serialized_end=53
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
**Public-Facing Changes**
Adds a parameter to `get_messages` to allow end-users to supply their own message decoding implementation(s).

**Description**
Users can upload MCAP data with any message/schema encoding to data platform, and they may want to use `get_messages` even if we don't have a support library for their specific encoding.
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
