### PR TITLE
Search all sources

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -33,3 +33,4 @@ python_version = "3"
 
 [pipenv]
 allow_prereleases = true
+install_search_all_sources = true


### PR DESCRIPTION
Set `install_search_all_sources = true` for pipenv, to match legacy behavior: https://pipenv.pypa.io/en/latest/advanced/#specifying-package-indexes.

`pipenv`, starting with `2022.3.23`, restricts each package to a single source for security reasons. This change to the default behavior broke CI installs. As far as I can tell, resolution for transitive dependencies uses the default source, rather than the source specified for the intermediate dependency. For example, `catkin` was no longer found (in pypi), even though it's imported via rosbag, which we specify with `index="ros"` ([example action](https://github.com/foxglove/py-data-platform/actions/runs/3855588765/jobs/6570797783)). 

Per the docs, it may be acceptable to continue to search all sources, as long as we're confident in our lock file. Note I'm not particularly experienced with the python ecosystem and am not necessarily recommending this as the best path forward, but it seems a simple way to unblock our deployments. I am certainly open to other suggestions.

Draft PR https://github.com/foxglove/py-data-platform/pull/65 includes some other things I tried.