### PR TITLE
create_device: remove serial number argument

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -3,6 +3,7 @@ import os
 from enum import Enum
 from io import BytesIO
 import json
+import warnings
 from typing import IO, Any, Dict, List, Optional, Union
 
 import arrow
@@ -400,7 +401,6 @@ class Client:
         return {
             "id": device["id"],
             "name": device["name"],
-            "serial_number": device["serialNumber"],
             "created_at": arrow.get(device["createdAt"]).datetime,
             "updated_at": arrow.get(device["updatedAt"]).datetime,
         }
@@ -420,7 +420,6 @@ class Client:
             {
                 "id": d["id"],
                 "name": d["name"],
-                "serial_number": d["serialNumber"],
                 "created_at": arrow.get(d["createdAt"]).datetime,
                 "updated_at": arrow.get(d["updatedAt"]).datetime,
             }
@@ -430,21 +429,20 @@ class Client:
     def create_device(
         self,
         name: str,
-        serial_number: str,
+        serial_number: Optional[str] = None,
     ):
         """
         Creates a new device.
 
-        device_id: The name of the devicee.
-        serial_number: The unique serial number of the devicde.
+        name: The name of the devicee.
+        serial_number: DEPRECATED: a serial number for the device. This argument has no effect.
         """
+        if serial_number is not None:
+            warnings.warn(
+                "serial number argument is deprecated and will be removed in the next release"
+            )
         response = requests.post(
-            self.__url__("/v1/devices"),
-            headers=self.__headers,
-            json={
-                "name": name,
-                "serialNumber": serial_number,
-            },
+            self.__url__("/v1/devices"), headers=self.__headers, json={"name": name}
         )
 
         device = json_or_raise(response)
@@ -452,7 +450,6 @@ class Client:
         return {
             "id": device["id"],
             "name": device["name"],
-            "serial_number": device["serialNumber"],
         }
 
     def delete_device(self, device_id: str):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.2.3
+version = 0.3.0
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -13,19 +13,17 @@ fake = Faker()
 def test_create_device():
     id = fake.uuid4()
     name = "name"
-    serial_number = "serial"
     responses.add(
         responses.POST,
         api_url("/v1/devices"),
         json={
             "id": id,
             "name": name,
-            "serialNumber": serial_number,
         },
     )
     client = Client("test")
-    device = client.create_device(name=name, serial_number=serial_number)
-    assert device["serial_number"] == serial_number
+    device = client.create_device(name=name)
+    assert device["name"] == name
 
 
 @responses.activate
@@ -37,7 +35,6 @@ def test_get_device():
         json={
             "id": id,
             "name": fake.sentence(2),
-            "serialNumber": fake.pyint(),
             "createdAt": datetime.now().isoformat(),
             "updatedAt": datetime.now().isoformat(),
         },
@@ -57,7 +54,6 @@ def test_get_devices():
             {
                 "id": id,
                 "name": fake.sentence(2),
-                "serialNumber": fake.pyint(),
                 "createdAt": datetime.now().isoformat(),
                 "updatedAt": datetime.now().isoformat(),
             }
@@ -72,8 +68,6 @@ def test_get_devices():
 @responses.activate
 def test_delete_device():
     id = fake.uuid4()
-    name = "name"
-    serial_number = "serial"
     responses.add(
         responses.DELETE,
         api_url(f"/v1/devices/{id}"),


### PR DESCRIPTION
**Public-Facing Changes**
* deprecates `serial_number` argument in create_device.

**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
