### PR TITLE
Serialize boolean get param

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -69,6 +69,13 @@ def camelize(snake_name: Optional[str]) -> Optional[str]:
     return "".join([parts[0]] + [w.title() for w in parts[1:]])
 
 
+def bool_query_param(val: bool) -> Optional[str]:
+    """
+    Serialize a bool to an API query parameter (e.g. True -> "true")
+    """
+    return str(val).lower() if val is not None else None
+
+
 class FoxgloveException(Exception):
     pass
 
@@ -515,7 +522,7 @@ class Client:
             "end": end.astimezone().isoformat() if end else None,
             "dataStart": data_start.astimezone().isoformat() if data_start else None,
             "dataEnd": data_end.astimezone().isoformat() if data_end else None,
-            "includeDeleted": include_deleted,
+            "includeDeleted": bool_query_param(include_deleted),
             "filename": filename,
             "sortBy": camelize(sort_by),
             "sortOrder": sort_order,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.3.0
+version = 0.3.1
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This fixes the serialization of the boolean `include_deleted` parameter to `get_imports`. The API expects a value serialized as "true" or "false" from the query string. This is the only instance of a `bool` parameter in the client.

This also bumps the version to 0.3.1 for a planned patch release.