### PR TITLE
Remove undocumented fields from response objects

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -408,8 +408,6 @@ class Client:
         return {
             "id": device["id"],
             "name": device["name"],
-            "created_at": arrow.get(device["createdAt"]).datetime,
-            "updated_at": arrow.get(device["updatedAt"]).datetime,
         }
 
     def get_devices(self):
@@ -427,8 +425,6 @@ class Client:
             {
                 "id": d["id"],
                 "name": d["name"],
-                "created_at": arrow.get(d["createdAt"]).datetime,
-                "updated_at": arrow.get(d["updatedAt"]).datetime,
             }
             for d in json
         ]
@@ -543,7 +539,6 @@ class Client:
                 "import_time": arrow.get(i["importTime"]).datetime,
                 "start": arrow.get(i["start"]).datetime,
                 "end": arrow.get(i["end"]).datetime,
-                "metadata": i["metadata"],
                 "input_type": i["inputType"],
                 "output_type": i["outputType"],
                 "filename": i["filename"],

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.3.1
+version = 0.4.0
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
**Public-Facing Changes**

This updates the return types for the following client calls, removing any fields that are not publicly documented:

- `get_device` (timestamps)
- `get_devices` (timestamps)
- `get_imports` (metadata)

This fixes an issue with the current API version where timestamps are not included in the response to `devices/{id}`.

This includes a version bump to 0.4.0.