### PR TITLE
migrate to use v/1events, force keyword arguments on all client methods

### DIFF
--- a/examples/events.py
+++ b/examples/events.py
@@ -6,13 +6,15 @@ token = "<YOUR API TOKEN>"
 device_id = "<YOUR DEVICE ID>"
 client = Client(token=token)
 
+event_time = datetime.now()
+
 event = client.create_event(
     device_id=device_id,
-    time=datetime.now(),
-    duration=0,
+    start=event_time,
+    end=event_time,
     metadata={"message": "Hi from python!"},
 )
 print(event)
 
-events = client.get_events()
+events = client.get_events(device_id=device_id)
 print(events)

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -160,26 +160,29 @@ class Client:
         self,
         *,
         device_id: str,
-        time: datetime.datetime,
-        duration: int,
+        start: datetime.datetime,
+        end: Optional[datetime.datetime],
         metadata: Optional[Dict[str, str]] = {},
     ):
         """
         Creates a new event.
 
         device_id: The unique of the device associated with this event.
-        time: The time at which the event occurred.
-        duration: The duration of the event. Zero for an instantaneous event.
+        start: The event start time.
+        end: The event end time. If not provided, an instantaneous event (with end == start)
+            is created.
         metadata: Optional metadata attached to the event.
         """
+        if end is None:
+            end = start
         response = requests.post(
-            self.__url__("/beta/device-events"),
+            self.__url__("/v1/events"),
             headers=self.__headers,
             json={
                 "deviceId": device_id,
-                "durationNanos": str(duration),
+                "start": start.astimezone().isoformat(),
+                "end": end.astimezone().isoformat(),
                 "metadata": metadata,
-                "timestamp": time.astimezone().isoformat(),
             },
         )
 

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -186,16 +186,7 @@ class Client:
             },
         )
 
-        event = json_or_raise(response)
-        return {
-            "id": event["id"],
-            "device_id": event["deviceId"],
-            "timestamp_nanos": event["timestampNanos"],
-            "duration_nanos": event["durationNanos"],
-            "metadata": event["metadata"],
-            "created_at": arrow.get(event["createdAt"]).datetime,
-            "updated_at": arrow.get(event["updatedAt"]).datetime,
-        }
+        return _event_dict(json_or_raise(response))
 
     def delete_event(
         self,
@@ -630,6 +621,16 @@ class Client:
             "text": upload_request.text,
             "code": upload_request.status_code,
         }
+
+def _event_dict(json_event):
+    return {
+        "id": json_event["id"],
+        "start": datetime.datetime.fromisoformat(json_event["start"]),
+        "end": datetime.datetime.fromisoformat(json_event["end"]),
+        "metadata": json_event["metadata"],
+        "created_at": datetime.datetime.fromisoformat(json_event["createdAt"]),
+        "updated_at": datetime.datetime.fromisoformat(json_event["updatedAt"]),
+    }
 
 
 __all__ = ["Client", "FoxgloveException", "OutputFormat"]

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -207,7 +207,7 @@ class Client:
     def get_events(
         self,
         *,
-        device_id: str,
+        device_id: Optional[str] = None,
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         limit: Optional[int] = None,

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -199,10 +199,10 @@ class Client:
         event_id: The id of the event to delete.
         """
         response = requests.delete(
-            self.__url__(f"/beta/device-events/{event_id}"),
+            self.__url__(f"/v1/events/{event_id}"),
             headers=self.__headers,
         )
-        json_or_raise(response)
+        return json_or_raise(response)
 
     def get_events(
         self,

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -158,6 +158,7 @@ class Client:
 
     def create_event(
         self,
+        *,
         device_id: str,
         time: datetime.datetime,
         duration: int,
@@ -195,6 +196,7 @@ class Client:
 
     def delete_event(
         self,
+        *,
         event_id: str,
     ):
         """
@@ -210,6 +212,7 @@ class Client:
 
     def get_events(
         self,
+        *,
         device_id: Optional[str] = None,
         device_name: Optional[str] = None,
         sort_by: Optional[str] = None,
@@ -276,6 +279,7 @@ class Client:
 
     def get_messages(
         self,
+        *,
         device_id: str,
         start: datetime.datetime,
         end: datetime.datetime,
@@ -313,6 +317,7 @@ class Client:
 
     def download_data(
         self,
+        *,
         device_id: str,
         start: datetime.datetime,
         end: datetime.datetime,
@@ -356,6 +361,7 @@ class Client:
 
     def get_coverage(
         self,
+        *,
         start: datetime.datetime,
         end: datetime.datetime,
         device_id: Optional[str] = None,
@@ -392,7 +398,7 @@ class Client:
             for c in json
         ]
 
-    def get_device(self, device_id: str):
+    def get_device(self, *, device_id: str):
         """
         Gets a single device by id.
 
@@ -431,6 +437,7 @@ class Client:
 
     def create_device(
         self,
+        *,
         name: str,
         serial_number: Optional[str] = None,
     ):
@@ -455,7 +462,7 @@ class Client:
             "name": device["name"],
         }
 
-    def delete_device(self, device_id: str):
+    def delete_device(self, *, device_id: str):
         """
         Deletes an existing device.
 
@@ -469,7 +476,7 @@ class Client:
         )
         json_or_raise(response)
 
-    def delete_import(self, device_id: str, import_id: str):
+    def delete_import(self, *, device_id: str, import_id: str):
         """
         Deletes an existing import.
 
@@ -485,6 +492,7 @@ class Client:
 
     def get_imports(
         self,
+        *,
         device_id: Optional[str] = None,
         start: Optional[datetime.datetime] = None,
         end: Optional[datetime.datetime] = None,
@@ -550,6 +558,7 @@ class Client:
 
     def get_topics(
         self,
+        *,
         device_id: str,
         start: datetime.datetime,
         end: datetime.datetime,
@@ -580,6 +589,7 @@ class Client:
 
     def upload_data(
         self,
+        *,
         device_id: str,
         filename: str,
         data: Union[bytes, IO[Any]],

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.4.0
+version = 0.5.0
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -42,7 +42,7 @@ def test_create_event():
 def test_delete_event():
     id = fake.uuid4()
     responses.add(
-        responses.DELETE, api_url(f"/beta/device-events/{id}"), json={"success": True}
+        responses.DELETE, api_url(f"/v1/events/{id}"), json={"id": id}
     )
     client = Client("test")
     try:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -22,6 +22,7 @@ def test_create_event():
         api_url("/v1/events"),
         json={
             "id": id,
+            "deviceId": device_id,
             "start": start.astimezone().isoformat(),
             "end": end.astimezone().isoformat(),
             "metadata": {"foo": "bar"},
@@ -32,6 +33,7 @@ def test_create_event():
     client = Client("test")
     event = client.create_event(device_id=device_id, start=start, end=end)
     assert event["start"] == start
+    assert event["device_id"] == device_id
     assert event["end"] == end
     assert event["id"] == id
     assert event["created_at"] == now
@@ -41,9 +43,7 @@ def test_create_event():
 @responses.activate
 def test_delete_event():
     id = fake.uuid4()
-    responses.add(
-        responses.DELETE, api_url(f"/v1/events/{id}"), json={"id": id}
-    )
+    responses.add(responses.DELETE, api_url(f"/v1/events/{id}"), json={"id": id})
     client = Client("test")
     try:
         client.delete_event(event_id=id)
@@ -54,22 +54,30 @@ def test_delete_event():
 @responses.activate
 def test_get_events():
     device_id = "my_device_id"
+    start = datetime.datetime.now().astimezone()
+    end = start + datetime.timedelta(seconds=10)
+    now = datetime.datetime.now().astimezone()
     responses.add(
         responses.GET,
-        api_url(f"/beta/device-events?deviceId={device_id}"),
+        api_url(f"/v1/events?deviceId={device_id}"),
         json=[
             {
                 "id": "1",
-                "createdAt": datetime.datetime.now().isoformat(),
                 "deviceId": device_id,
-                "durationNanos": fake.pyint(),
                 "metadata": {},
-                "timestampNanos": fake.pyint(),
-                "updatedAt": datetime.datetime.now().isoformat(),
+                "start": start.astimezone().isoformat(),
+                "end": end.astimezone().isoformat(),
+                "createdAt": now.astimezone().isoformat(),
+                "updatedAt": now.astimezone().isoformat(),
             }
         ],
     )
     client = Client("test")
-    events = client.get_events(device_id=device_id)
-    assert len(events) == 1
-    assert events[0]["device_id"] == device_id
+    [event] = client.get_events(device_id=device_id)
+    assert event["id"] == "1"
+    assert event["device_id"] == device_id
+    assert event["start"] == start
+    assert event["end"] == end
+    assert event["created_at"] == now
+    assert event["updated_at"] == now
+    assert event["metadata"] == {}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime
+import datetime
 
 import responses
 from faker import Faker
@@ -14,23 +14,28 @@ fake = Faker()
 def test_create_event():
     id = fake.uuid4()
     device_id = fake.uuid4()
+    start = datetime.datetime.now().astimezone()
+    end = start + datetime.timedelta(seconds=10)
+    now = datetime.datetime.now().astimezone()
     responses.add(
         responses.POST,
-        api_url("/beta/device-events"),
+        api_url("/v1/events"),
         json={
             "id": id,
-            "deviceId": device_id,
-            "timestampNanos": str(time.time_ns()),
-            "durationNanos": "1",
+            "start": start.astimezone().isoformat(),
+            "end": end.astimezone().isoformat(),
             "metadata": {"foo": "bar"},
-            "createdAt": datetime.now().isoformat(),
-            "updatedAt": datetime.now().isoformat(),
+            "createdAt": now.astimezone().isoformat(),
+            "updatedAt": now.astimezone().isoformat(),
         },
     )
     client = Client("test")
-    event = client.create_event(device_id=device_id, time=datetime.now(), duration=1)
+    event = client.create_event(device_id=device_id, start=start, end=end)
+    assert event["start"] == start
+    assert event["end"] == end
     assert event["id"] == id
-    assert event["device_id"] == device_id
+    assert event["created_at"] == now
+    assert event["updated_at"] == now
 
 
 @responses.activate
@@ -55,12 +60,12 @@ def test_get_events():
         json=[
             {
                 "id": "1",
-                "createdAt": datetime.now().isoformat(),
+                "createdAt": datetime.datetime.now().isoformat(),
                 "deviceId": device_id,
                 "durationNanos": fake.pyint(),
                 "metadata": {},
                 "timestampNanos": fake.pyint(),
-                "updatedAt": datetime.now().isoformat(),
+                "updatedAt": datetime.datetime.now().isoformat(),
             }
         ],
     )


### PR DESCRIPTION
### Public-Facing Changes

* Callers are forced to use keyword arguments on all Client methods. This makes migration slightly easier for users when we make breaking API changes. This change itself is a breaking change compared to the current released version of the library.
* `get_events`, `create_event` and `delete_event` are updated to fit the `/v1/events` stable API.

### Description

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
