### PR TITLE
Add methods to list and download recordings and attachments

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -645,10 +645,10 @@ class Client:
         return [
             {
                 "id": i["id"],
-                "recordingId": i["recordingId"],
-                "siteId": i["siteId"],
+                "recording_id": i["recordingId"],
+                "site_id": i["siteId"],
                 "name": i["name"],
-                "mediaType": i["mediaType"],
+                "media_type": i["mediaType"],
                 "size": i["size"],
                 "crc": i["crc"],
                 "fingerprint": i["fingerprint"],

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -622,7 +622,7 @@ class Client:
         :param recording_id: Optionally filter responses by this recording ID.
         :param site_id: Optionally filter responses by this site ID.
         :param sort_by: Optionally sort responses by this field name.
-            currently only "logTime" is supported.
+            currently only "log_time" is supported.
         :param sort_order: Optionally specify the sort order, either "asc" or "desc".
         :param limit: Optionally limit the number of records returned.
         :param offset: Optionally offset the results by this many records.

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -528,6 +528,39 @@ class Client:
             for i in json
         ]
 
+    def get_recordings(
+        self,
+        *,
+        device_id: Optional[str] = None,
+        start: Optional[datetime.datetime] = None,
+        end: Optional[datetime.datetime] = None,
+        path: Optional[str] = None,
+        site_id: Optional[str] = None,
+        edge_site_id: Optional[str] = None,
+        import_status: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
+    ):
+        pass
+
+    def get_attachments(
+        self,
+        *,
+        device_id: Optional[str] = None,
+        recording_id: Optional[str] = None,
+        site_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
+    ):
+        pass
+
+    def download_attachment(self, *, attachment_id: str):
+        pass
+
     def get_topics(
         self,
         *,

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -563,24 +563,30 @@ class Client:
         )
         json = json_or_raise(response)
 
-        return [
-            {
-                "id": i["id"],
-                "path": i["path"],
-                "size": i["size"],
-                "message_count": i["messageCount"],
-                "created_at": arrow.get(i["createdAt"]).datetime,
-                "imported_at": arrow.get(i["importedAt"]).datetime,
-                "start": arrow.get(i["start"]).datetime,
-                "end": arrow.get(i["end"]).datetime,
-                "import_status": i["import_status"],
-                "site": i["site"],
-                "edge_site": i["edge_site"],
-                "device": i["device"],
-                "metadata": i["metadata"],
-            }
-            for i in json
-        ]
+        out = []
+        for i in json:
+            imported_at = i.get("importedAt")
+            if imported_at is not None:
+                imported_at = arrow.get(imported_at).datetime
+            out.append(
+                {
+                    "id": i["id"],
+                    "path": i["path"],
+                    "size": i["size"],
+                    "message_count": i.get("messageCount"),
+                    "created_at": arrow.get(i["createdAt"]).datetime,
+                    "imported_at": imported_at,
+                    "start": arrow.get(i["start"]).datetime,
+                    "end": arrow.get(i["end"]).datetime,
+                    "import_status": i["importStatus"],
+                    "site": i.get("site"),
+                    "edge_site": i.get("edgeSite"),
+                    "device": i.get("device"),
+                    "metadata": i.get("metadata"),
+                }
+            )
+
+        return out
 
     def get_attachments(
         self,
@@ -631,7 +637,7 @@ class Client:
         callback: Optional[ProgressCallback] = None,
     ):
         response = requests.get(
-            self.__url__(f"v1/recording-attachments/{attachment_id}/download"),
+            self.__url__(f"/v1/recording-attachments/{attachment_id}/download"),
             stream=True,
             allow_redirects=True,
         )

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -311,7 +311,7 @@ class Client:
         callback: Optional[ProgressCallback] = None,
     ):
         """
-        Returns raw data bytes for a specific recording.
+        Returns raw data bytes for a recording.
 
         :param id: the ID of the recording.
         :param include_attachments: whether to include MCAP attachments in the returned data.

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -543,6 +543,23 @@ class Client:
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
     ):
+        """Fetches recordings.
+
+        :param device_id: Optionally filter responses by this device ID.
+        :param start: Optionally specify the start of an inclusive time range.
+            Only recordings with messages within this time range will be returned.
+        :param end: Optionally specify the end of an inclusive time range.
+            Only recordings with messages within this time range will be returned.
+        :param path: Optionally filter responses to recordings with a matching path.
+        :param site_id: Optionally filter responses to recordings stored at this primary site.
+        :param edge_site_id: Optionally filter responses to recordings stored at this edge site.
+        :param import_status: Optionally filter responses to recordings with this import status.
+        :param sort_by: Optionally sort returned recordings by a field in the response type.
+            Specifying duration sorts by the duration between the recording start and end fields.
+        :param sort_order: Optionally specify the sort order, either "asc" or "desc".
+        :param limit: Optionally limit the number of records returned.
+        :param offset: Optionally offset the results by this many records.
+        """
         all_params = {
             "device.id": device_id,
             "start": start.astimezone().isoformat() if start else None,
@@ -599,6 +616,17 @@ class Client:
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
     ):
+        """List recording attachments.
+
+        :param device_id: Optionally filter responses by this device ID.
+        :param recording_id: Optionally filter responses by this recording ID.
+        :param site_id: Optionally filter responses by this site ID.
+        :param sort_by: Optionally sort responses by this field name.
+            currently only "logTime" is supported.
+        :param sort_order: Optionally specify the sort order, either "asc" or "desc".
+        :param limit: Optionally limit the number of records returned.
+        :param offset: Optionally offset the results by this many records.
+        """
         all_params = {
             "deviceId": device_id,
             "siteId": site_id,
@@ -636,6 +664,12 @@ class Client:
         attachment_id: str,
         callback: Optional[ProgressCallback] = None,
     ):
+        """Download an attachment by ID.
+
+        :param attachment_id: the attachment ID.
+        :param callback: a callback to track download progress
+        :returns: The downloaded attachment bytes.
+        """
         response = requests.get(
             self.__url__(f"/v1/recording-attachments/{attachment_id}/download"),
             stream=True,

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -324,6 +324,7 @@ class Client:
 
         link = json["link"]
         response = requests.get(link, stream=True)
+        response.raise_for_status()
         data = BytesIO()
         for chunk in response.iter_content(chunk_size=32 * 1024):
             data.write(chunk)
@@ -672,9 +673,10 @@ class Client:
         """
         response = requests.get(
             self.__url__(f"/v1/recording-attachments/{attachment_id}/download"),
+            headers=self.__headers,
             stream=True,
-            allow_redirects=True,
         )
+        response.raise_for_status()
         data = BytesIO()
         for chunk in response.iter_content(chunk_size=32 * 1024):
             data.write(chunk)

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -145,7 +145,6 @@ def json_or_raise(response: requests.Response):
     return json
 
 
-
 class Client:
     def __init__(self, token: str, host: str = "api.foxglove.dev"):
         self.__token = token
@@ -158,7 +157,9 @@ class Client:
     def __url__(self, path: str):
         return f"https://{self.__host}{path}"
 
-    def _download_stream_with_progress(self, url: str, callback: Optional[ProgressCallback] = None):
+    def _download_stream_with_progress(
+        self, url: str, callback: Optional[ProgressCallback] = None
+    ):
         response = requests.get(url, headers=self.__headers, stream=True)
         response.raise_for_status()
         data = BytesIO()
@@ -311,7 +312,7 @@ class Client:
 
         :param id: the ID of the recording.
         :param include_attachments: whether to include MCAP attachments in the returned data.
-        :param output_format: The output format of the data, defaulting to .mcap. 
+        :param output_format: The output format of the data, defaulting to .mcap.
             Note: You can only export a .bag file if you originally uploaded a .bag file.
         :param callback: an optional callback to report download progress.
         """

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -543,7 +543,44 @@ class Client:
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
     ):
-        pass
+        all_params = {
+            "device.id": device_id,
+            "start": start.astimezone().isoformat() if start else None,
+            "end": end.astimezone().isoformat() if end else None,
+            "site.id": site_id,
+            "edgeSite.id": edge_site_id,
+            "importStatus": import_status,
+            "path": path,
+            "sortBy": camelize(sort_by),
+            "sortOrder": sort_order,
+            "limit": limit,
+            "offset": offset,
+        }
+        response = requests.get(
+            self.__url__("/v1/recordings"),
+            params={k: v for k, v in all_params.items() if v is not None},
+            headers=self.__headers,
+        )
+        json = json_or_raise(response)
+
+        return [
+            {
+                "id": i["id"],
+                "path": i["path"],
+                "size": i["size"],
+                "message_count": i["messageCount"],
+                "created_at": arrow.get(i["createdAt"]).datetime,
+                "imported_at": arrow.get(i["importedAt"]).datetime,
+                "start": arrow.get(i["start"]).datetime,
+                "end": arrow.get(i["end"]).datetime,
+                "import_status": i["import_status"],
+                "site": i["site"],
+                "edge_site": i["edge_site"],
+                "device": i["device"],
+                "metadata": i["metadata"],
+            }
+            for i in json
+        ]
 
     def get_attachments(
         self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.5.0
+version = 0.6.0
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/string_message_pb2.py
+++ b/tests/string_message_pb2.py
@@ -7,28 +7,31 @@ from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
 
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
+    b'\n\x14string_message.proto"\x1d\n\rStringMessage\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\tb\x06proto3'
+)
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14string_message.proto\"\x1d\n\rStringMessage\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\tb\x06proto3')
-
-
-
-_STRINGMESSAGE = DESCRIPTOR.message_types_by_name['StringMessage']
-StringMessage = _reflection.GeneratedProtocolMessageType('StringMessage', (_message.Message,), {
-  'DESCRIPTOR' : _STRINGMESSAGE,
-  '__module__' : 'string_message_pb2'
-  # @@protoc_insertion_point(class_scope:StringMessage)
-  })
+_STRINGMESSAGE = DESCRIPTOR.message_types_by_name["StringMessage"]
+StringMessage = _reflection.GeneratedProtocolMessageType(
+    "StringMessage",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _STRINGMESSAGE,
+        "__module__": "string_message_pb2"
+        # @@protoc_insertion_point(class_scope:StringMessage)
+    },
+)
 _sym_db.RegisterMessage(StringMessage)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
-
-  DESCRIPTOR._options = None
-  _STRINGMESSAGE._serialized_start=24
-  _STRINGMESSAGE._serialized_end=53
+    DESCRIPTOR._options = None
+    _STRINGMESSAGE._serialized_start = 24
+    _STRINGMESSAGE._serialized_end = 53
 # @@protoc_insertion_point(module_scope)

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -8,6 +8,7 @@ from .api_url import api_url
 
 fake = Faker()
 
+
 @responses.activate
 def test_get_attachments():
     device_id = fake.uuid4()
@@ -46,16 +47,16 @@ def test_get_attachments():
     )
     assert attachments == [
         {
-                "id": attachment_id,
-                "recording_id": recording_id,
-                "site_id": site_id,
-                "name": path,
-                "media_type": media_type,
-                "size": size,
-                "crc": crc,
-                "fingerprint": fingerprint,
-                "log_time": now,
-                "create_time": now,
+            "id": attachment_id,
+            "recording_id": recording_id,
+            "site_id": site_id,
+            "name": path,
+            "media_type": media_type,
+            "size": size,
+            "crc": crc,
+            "fingerprint": fingerprint,
+            "log_time": now,
+            "create_time": now,
         },
     ]
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,24 @@
+import responses
+from faker import Faker
+from foxglove_data_platform.client import Client
+import arrow
+
+from .api_url import api_url
+
+fake = Faker()
+
+
+@responses.activate
+def test_download_attachment():
+    id = "abcde"
+    data = fake.binary(4096)
+    responses.add(
+        responses.GET,
+        api_url(f"/v1/recording-attachments/{id}/download"),
+        body=data,
+    )
+    client = Client("test")
+    response_data = client.download_attachment(
+        attachment_id=id,
+    )
+    assert data == response_data

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,11 +1,63 @@
 import responses
 from faker import Faker
 from foxglove_data_platform.client import Client
-import arrow
+from datetime import datetime
+from dateutil.tz import tzoffset
 
 from .api_url import api_url
 
 fake = Faker()
+
+@responses.activate
+def test_get_attachments():
+    device_id = fake.uuid4()
+    attachment_id = fake.uuid4()
+    recording_id = fake.uuid4()
+    path = fake.file_name(extension="txt")
+    media_type = fake.mime_type()
+    size = fake.random_number()
+    crc = fake.random_number()
+    fingerprint = fake.uuid4()
+    site_id = fake.uuid4()
+    now = datetime.now(tzoffset(None, 0))
+
+    responses.add(
+        responses.GET,
+        api_url(f"/v1/recording-attachments"),
+        json=[
+            {
+                "id": attachment_id,
+                "recordingId": recording_id,
+                "siteId": site_id,
+                "name": path,
+                "mediaType": media_type,
+                "size": size,
+                "crc": crc,
+                "fingerprint": fingerprint,
+                "logTime": now.isoformat(),
+                "createTime": now.isoformat(),
+            },
+        ],
+        match=[responses.matchers.query_string_matcher("sortBy=logTime")],
+    )
+    client = Client("test")
+    attachments = client.get_attachments(
+        sort_by="log_time",
+    )
+    assert attachments == [
+        {
+                "id": attachment_id,
+                "recording_id": recording_id,
+                "site_id": site_id,
+                "name": path,
+                "media_type": media_type,
+                "size": size,
+                "crc": crc,
+                "fingerprint": fingerprint,
+                "log_time": now,
+                "create_time": now,
+        },
+    ]
 
 
 @responses.activate

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -71,7 +71,5 @@ def test_download_attachment():
         body=data,
     )
     client = Client("test")
-    response_data = client.download_attachment(
-        attachment_id=id,
-    )
+    response_data = client.download_attachment(id=id)
     assert data == response_data

--- a/tests/test_json_messages.py
+++ b/tests/test_json_messages.py
@@ -13,5 +13,5 @@ def test_download_with_decoder():
         device_id="test_id", start=datetime.now(), end=datetime.now()
     )
     assert len(messages) == 10
-    for (_, _, msg) in messages:
+    for _, _, msg in messages:
         assert "level" in msg

--- a/tests/test_recordings.py
+++ b/tests/test_recordings.py
@@ -9,6 +9,7 @@ from .api_url import api_url
 
 fake = Faker()
 
+
 @responses.activate
 def test_get_recordings():
     device_id = fake.uuid4()
@@ -35,9 +36,9 @@ def test_get_recordings():
                 "start": now.isoformat(),
                 "end": now.isoformat(),
                 "importStatus": "complete",
-                "site": { "id": site_id, "name": "primarySite"},
+                "site": {"id": site_id, "name": "primarySite"},
                 "device": {"id": device_id, "name": "deviceName"},
-                "metadata": { "hey": "now", "brown": "cow"},
+                "metadata": {"hey": "now", "brown": "cow"},
             },
             {
                 "id": recording_id_b,
@@ -48,14 +49,16 @@ def test_get_recordings():
                 "start": now.isoformat(),
                 "end": now.isoformat(),
                 "importStatus": "none",
-                "edgeSite": { "id": edge_site_id, "name": "edgeSite"},
+                "edgeSite": {"id": edge_site_id, "name": "edgeSite"},
                 "device": {"id": device_id, "name": "deviceName"},
             },
         ],
     )
     client = Client("test")
     recordings = client.get_recordings(
-        start=datetime.now(), end=datetime.now(), device_id=device_id,
+        start=datetime.now(),
+        end=datetime.now(),
+        device_id=device_id,
     )
     assert recordings == [
         {
@@ -68,10 +71,10 @@ def test_get_recordings():
             "start": now,
             "end": now,
             "import_status": "complete",
-            "site": { "id": site_id, "name": "primarySite"},
+            "site": {"id": site_id, "name": "primarySite"},
             "edge_site": None,
             "device": {"id": device_id, "name": "deviceName"},
-            "metadata": { "hey": "now", "brown": "cow"},
+            "metadata": {"hey": "now", "brown": "cow"},
         },
         {
             "id": recording_id_b,
@@ -84,7 +87,7 @@ def test_get_recordings():
             "import_status": "none",
             "imported_at": None,
             "site": None,
-            "edge_site": { "id": edge_site_id, "name": "edgeSite"},
+            "edge_site": {"id": edge_site_id, "name": "edgeSite"},
             "device": {"id": device_id, "name": "deviceName"},
             "metadata": None,
         },

--- a/tests/test_recordings.py
+++ b/tests/test_recordings.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+from dateutil.tz import tzoffset
+
+import responses
+from faker import Faker
+from foxglove_data_platform.client import Client
+
+from .api_url import api_url
+
+fake = Faker()
+
+@responses.activate
+def test_get_recordings():
+    device_id = fake.uuid4()
+    recording_id_a = fake.uuid4()
+    recording_id_b = fake.uuid4()
+    path = fake.file_name(extension="mcap")
+    size = fake.random_number()
+    message_count = fake.random_number()
+    site_id = fake.uuid4()
+    edge_site_id = fake.uuid4()
+    now = datetime.now(tzoffset(None, 0))
+
+    responses.add(
+        responses.GET,
+        api_url(f"/v1/recordings"),
+        json=[
+            {
+                "id": recording_id_a,
+                "path": path,
+                "size": size,
+                "messageCount": message_count,
+                "createdAt": now.isoformat(),
+                "importedAt": now.isoformat(),
+                "start": now.isoformat(),
+                "end": now.isoformat(),
+                "importStatus": "complete",
+                "site": { "id": site_id, "name": "primarySite"},
+                "device": {"id": device_id, "name": "deviceName"},
+                "metadata": { "hey": "now", "brown": "cow"},
+            },
+            {
+                "id": recording_id_b,
+                "path": path,
+                "size": size,
+                "messageCount": message_count,
+                "createdAt": now.isoformat(),
+                "start": now.isoformat(),
+                "end": now.isoformat(),
+                "importStatus": "none",
+                "edgeSite": { "id": edge_site_id, "name": "edgeSite"},
+                "device": {"id": device_id, "name": "deviceName"},
+            },
+        ],
+    )
+    client = Client("test")
+    recordings = client.get_recordings(
+        start=datetime.now(), end=datetime.now(), device_id=device_id,
+    )
+    assert recordings == [
+        {
+            "id": recording_id_a,
+            "path": path,
+            "size": size,
+            "message_count": message_count,
+            "created_at": now,
+            "imported_at": now,
+            "start": now,
+            "end": now,
+            "import_status": "complete",
+            "site": { "id": site_id, "name": "primarySite"},
+            "edge_site": None,
+            "device": {"id": device_id, "name": "deviceName"},
+            "metadata": { "hey": "now", "brown": "cow"},
+        },
+        {
+            "id": recording_id_b,
+            "path": path,
+            "size": size,
+            "message_count": message_count,
+            "created_at": now,
+            "start": now,
+            "end": now,
+            "import_status": "none",
+            "imported_at": None,
+            "site": None,
+            "edge_site": { "id": edge_site_id, "name": "edgeSite"},
+            "device": {"id": device_id, "name": "deviceName"},
+            "metadata": None,
+        },
+    ]


### PR DESCRIPTION
### Public-Facing Changes

Adds wrappers to list recordings, list attachments, download an attachment, and download a recording by ID.
<!-- describe any changes to the public interface or APIs, or write "None" -->

### Description

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
