### PR TITLE
Fix docstring param

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -706,7 +706,7 @@ class Client:
     ):
         """Download an attachment by ID.
 
-        :param attachment_id: the attachment ID.
+        :param id: the attachment ID.
         :param callback: a callback to track download progress
         :returns: The downloaded attachment bytes.
         """


### PR DESCRIPTION
This fixes the `id` param in the download_attachment docstring.