### PR TITLE
Ignore device ID in delete call

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -488,16 +488,15 @@ class Client:
         )
         json_or_raise(response)
 
-    def delete_import(self, *, device_id: str, import_id: str):
+    def delete_import(self, *, device_id: Optional[str] = None, import_id: str):
         """
         Deletes an existing import.
 
-        :param device_id: The id of the device associated with the import.
+        :param device_id: The id of the device associated with the import. (Deprecated.)
         :param import_id: The id of the import to delete.
         """
         response = requests.delete(
             self.__url__(f"/v1/data/imports/{import_id}"),
-            params={"deviceId": device_id},
             headers=self.__headers,
         )
         json_or_raise(response)

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -492,7 +492,7 @@ class Client:
         """
         Deletes an existing import.
 
-        :param device_id: The id of the device associated with the import. (Deprecated.)
+        :param device_id: The id of the device associated with the import. (Deprecated; ignored.)
         :param import_id: The id of the import to delete.
         """
         response = requests.delete(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.6.0
+version = 0.7.0
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -11,16 +11,15 @@ fake = Faker()
 
 @responses.activate
 def test_delete_import():
-    device_id = fake.uuid4()
     import_id = fake.uuid4()
     responses.add(
         responses.DELETE,
-        api_url(f"/v1/data/imports/{import_id}?deviceId={device_id}"),
+        api_url(f"/v1/data/imports/{import_id}"),
         json={"success": True},
     )
     try:
         client = Client("test")
-        client.delete_import(device_id=device_id, import_id=import_id)
+        client.delete_import(import_id=import_id)
     except:
         assert False
 


### PR DESCRIPTION
### Public-Facing Changes

This makes the `device_id` argument to `delete_import` optional.

### Description

The REST API no longer requires a device ID to be sent with deletion requests as the import IDs returned are unique. This brings the client method inline with those expectations. `device_id` is still a named kw argument to avoid breaking existing scripts.

Fixes #76.