### PR TITLE
Filter None parameters in event creation and data upload

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -197,16 +197,17 @@ class Client:
             raise RuntimeError(
                 "device_id or device_name must be provided to create_event"
             )
+        params = {
+            "device.id": device_id,
+            "device.name": device_name,
+            "start": start.astimezone().isoformat(),
+            "end": end.astimezone().isoformat(),
+            "metadata": metadata,
+        }
         response = requests.post(
             self.__url__("/v1/events"),
             headers=self.__headers,
-            json={
-                "device.id": device_id,
-                "device.name": device_name,
-                "start": start.astimezone().isoformat(),
-                "end": end.astimezone().isoformat(),
-                "metadata": metadata,
-            },
+            json={k: v for k, v in params.items() if v is not None},
         )
 
         return _event_dict(json_or_raise(response))
@@ -817,14 +818,15 @@ class Client:
         data: The raw data in .bag or .mcap format.
         callback: An optional callback to report progress on the upload.
         """
+        params = {
+            "device.id": device_id,
+            "device.name": device_name,
+            "filename": filename,
+        }
         link_response = requests.post(
             self.__url__("/v1/data/upload"),
             headers=self.__headers,
-            json={
-                "device.id": device_id,
-                "device.name": device_name,
-                "filename": filename,
-            },
+            json={k: v for k, v in params.items() if v is not None},
         )
 
         json = json_or_raise(link_response)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.8.0
+version = 0.8.1
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryFile
 import responses
 from faker import Faker
 from foxglove_data_platform.client import Client
+from responses.matchers import json_params_matcher
 
 from .api_url import api_url
 
@@ -57,9 +58,19 @@ def test_streaming_upload():
 @responses.activate
 def test_upload():
     upload_link = fake.url()
+    device_id = "test_device_id"
+    filename = "test_file.mcap"
     responses.add(
         responses.POST,
         api_url("/v1/data/upload"),
+        match=[
+            json_params_matcher(
+                {
+                    "device.id": device_id,
+                    "filename": filename,
+                },
+            )
+        ],
         json={
             "link": upload_link,
         },
@@ -68,6 +79,6 @@ def test_upload():
     client = Client("test")
     data = fake.binary(4096)
     upload_response = client.upload_data(
-        device_id="test_device_id", filename="test_file.mcap", data=data
+        device_id=device_id, filename=filename, data=data
     )
     assert upload_response["link"] == upload_link

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,6 +4,7 @@ import datetime
 import responses
 from faker import Faker
 from foxglove_data_platform.client import Client
+from responses.matchers import json_params_matcher
 
 from .api_url import api_url
 
@@ -21,6 +22,16 @@ def test_create_event():
     responses.add(
         responses.POST,
         api_url("/v1/events"),
+        match=[
+            json_params_matcher(
+                {
+                    "device.id": device_id,
+                    "start": start.astimezone().isoformat(),
+                    "end": end.astimezone().isoformat(),
+                    "metadata": {},
+                },
+            )
+        ],
         json={
             "id": id,
             "deviceId": device_id,


### PR DESCRIPTION
Since we introduced optional device name, if it is not supplied it will be set to None and converted to null in the request, which the API will reject. Other methods are already performing this filtering.