### PR TITLE
Fix reading from `recording-attachments` response

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -767,7 +767,6 @@ class Client:
             {
                 "id": i["id"],
                 "recording_id": i["recordingId"],
-                "device": i["device"],
                 "site_id": i["siteId"],
                 "name": i["name"],
                 "media_type": i["mediaType"],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -76,3 +76,27 @@ def test_camelize():
     assert camelize("a_field_name") == "aFieldName"
     assert camelize("aFieldName") == "aFieldName"
     assert camelize(None) is None
+
+@responses.activate
+def test_get_recording_attachments():
+    responses.add(
+        responses.GET,
+        api_url("/v1/recording-attachments"),
+        json=[
+            {
+                "id": "test",
+                "recordingId": "test_recording",
+                "siteId": "test_site",
+                "name": "name",
+                "mediateType": "json",
+                "size": 5,
+                "crc": "test_crc",
+                "fingerprint": "test_fingerprint",
+            }
+        ]
+    )
+
+    client = Client("test")
+    attachments = client.get_attachments(recording_id="test_recording")
+    assert len(attachments) == 1
+    assert attachments[0]["name"] == "name"


### PR DESCRIPTION
### Public-Facing Changes

Fixes issue with accessing json from response to `v1/recording-attachments`.  It seems that the `device` field was dropped from the API (https://foxglove.dev/docs/api#tag/Recording-Attachments/paths/~1recording-attachments~1%7Bid%7D/get) but the client wasn't updated to match.

### Description

Removes field that is no longer provided as part of the response.  Adds a simple test for exercising the workflow.