### PR TITLE
Downgrade pipenv to 2022.12.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: 3.8
           cache: pipenv
-      - run: pip install pipenv==2023.6.18
+      - run: pip install pipenv==2022.12.19
       - run: pipenv install --dev --deploy
       - run: pipenv run black --check --diff --color --exclude '.*_pb2.py' .
       - run: pipenv run pyright foxglove_data_platform


### PR DESCRIPTION
In #88, to resolve CI errors, I downgraded pipenv (first to 2022.12.19, then to 2023.6.18, which I had seen succeed in CI previously). Once merged to main, CI failed. The dependencies had been cached after successfully installing using the former version; the latter version doesn't work — confirmed in #90.

This should fix CI errors on main for now.