### PR TITLE
Skip build steps under some conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - run: pipenv run python -m build
 
       - name: Publish to TestPyPI
+        if: |
+          !github.event.pull_request.head.repo.fork &&
+          github.actor != 'dependabot[bot]'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
@@ -34,7 +37,9 @@ jobs:
           skip_existing: true
 
       - name: Publish to PyPI
-        if: ${{ startsWith(github.ref, 'refs/tags/releases/v') }}
+        if: |
+          !github.event.pull_request.head.repo.fork &&
+          startsWith(github.ref, 'refs/tags/releases/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
In particular, if the source of a PR is a fork do not run the test build. Doing so causes this CI step to fail because the API token is missing.

This is the approach used in the mcap repo: https://github.com/foxglove/mcap/blob/a68c76979d646fa90a24bff3457be2da0c371f0a/.github/workflows/ci.yml#L259