### PR TITLE
Bump release version to 0.12.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.10.0
+version = 0.12.0
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This skips 0.11.0. The version bump for that tag was skipped and the release job failed.