### PR TITLE
client: add method to stream messages asynchronously

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -290,6 +290,9 @@ class Client:
         """
         Returns a list of tuples of (topic, raw mcap record, decoded message).
 
+        .. deprecated:: 0.13.0
+            Use :func:`iter_messages` instead.
+
         device_id: The id of the device that originated the desired data.
         device_name: The name of the device that originated the desired data.
         start: The earliest time from which to retrieve data.
@@ -299,10 +302,6 @@ class Client:
         decoder_factories: an optional list of :py:class:`~mcap.decoder.DecoderFactory` instances
             used to decode message content.
         """
-        if device_id is None and device_name is None:
-            raise RuntimeError(
-                "device_id or device_name must be provided to get_messages"
-            )
         data = self.download_data(
             device_name=device_name,
             device_id=device_id,
@@ -340,7 +339,6 @@ class Client:
         decoder_factories: an optional list of :py:class:`~mcap.decoder.DecoderFactory` instances
             used to decode message content.
         """
-
         stream_link = self._make_stream_link(
             device_id=device_id,
             device_name=device_name,
@@ -397,6 +395,9 @@ class Client:
         topics: List[str] = [],
         output_format: OutputFormat = OutputFormat.mcap0,
     ) -> str:
+        if device_id is None and device_name is None:
+            raise RuntimeError("device_id or device_name must be provided")
+
         params = {
             "device.id": device_id,
             "device.name": device_name,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.12.0
+version = 0.13.0
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_stream_messages.py
+++ b/tests/test_stream_messages.py
@@ -1,0 +1,39 @@
+from io import BytesIO
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from mcap.records import Schema, Channel, Message
+
+from foxglove_data_platform.client import Client
+
+from .generate import generate_json_data
+
+
+def get_generated_data(url, **kwargs):
+    assert url == "the_link"
+
+    class Resp:
+        def __init__(self):
+            self.raw = BytesIO(generate_json_data())
+        
+        def raise_for_status(self):
+            return None
+
+    return Resp()
+    
+
+@patch("requests.get", side_effect=get_generated_data)
+def test_boot(arg):
+    client = Client("test")
+    client._make_stream_link = MagicMock(return_value="the_link")
+    count = 0
+    for schema, channel, message, decoded_message in client.iter_messages(
+        device_id="test_id", start=datetime.now(), end=datetime.now()
+    ):
+        assert "level" in decoded_message
+        assert isinstance(schema, Schema)
+        assert isinstance(channel, Channel)
+        assert isinstance(message, Message)
+        count += 1
+
+    assert count == 10

--- a/tests/test_stream_messages.py
+++ b/tests/test_stream_messages.py
@@ -15,12 +15,12 @@ def get_generated_data(url, **kwargs):
     class Resp:
         def __init__(self):
             self.raw = BytesIO(generate_json_data())
-        
+
         def raise_for_status(self):
             return None
 
     return Resp()
-    
+
 
 @patch("requests.get", side_effect=get_generated_data)
 def test_boot(arg):


### PR DESCRIPTION
### Public-Facing Changes

Adds `iter_messages`, for streaming messages from data platform asynchronously.

This method not have the same yielded type as `get_messages`, because the get_messages API was determined before we had proper message iteration in the MCAP python library. 

In detail:

|        | get_messages | iter_messages |
|  --- |--------------- | --------------- |
| stream behavior | downloads entire stream first | yields the first element as soon as it is downloaded |
| element type | (topic, `mcap.Message`, decoded message) | (`mcap.Schema`, `mcap.Channel`, `mcap.Message`, decoded message) |

In my opinion the `get_messages` API unneccessarily hides information from the MCAP that the user might want (like channel metadata, topic schema content). It's still easy for them to pull the topic out of the channel.
