### PR TITLE
ci.yml: PyPI uses oidc for auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   python:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -30,8 +32,6 @@ jobs:
           github.actor != 'dependabot[bot]'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TESTPYPI_API_TOKEN }}
           packages_dir: dist
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
@@ -42,6 +42,4 @@ jobs:
           startsWith(github.ref, 'refs/tags/releases/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: dist


### PR DESCRIPTION
### Public-Facing Changes

None.

### Description

I've set up pypi to authorize GitHub Actions to push packages from this repo, following this guide: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

After this change, the PYPI_API_TOKEN (and TESTPYPI) github secrets are no longer  required and can be removed.