### PR TITLE
Add deprecation warning for impending rename

### DIFF
--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -167,8 +167,8 @@ def _download_stream_with_progress(
 class Client:
     def __init__(self, token: str, host: str = "api.foxglove.dev"):
         warnings.warn(
-            "The `foxglove_data_platform` package has been renamed to `foxglove`."
-            + " Please migrate to `foxglove` to receive future updates.",
+            "The `foxglove-data-platform` package has been renamed to `foxglove-client`."
+            + " Please migrate to `foxglove-client` to receive future updates.",
             DeprecationWarning,
         )
         self.__token = token

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -309,6 +309,7 @@ class Client:
         decoder_factories: an optional list of :py:class:`~mcap.decoder.DecoderFactory` instances
             used to decode message content.
         """
+        warnings.warn("Use `iter_messages` instead.", DeprecationWarning)
         data = self.download_data(
             device_name=device_name,
             device_id=device_id,
@@ -644,6 +645,10 @@ class Client:
         :param device_id: The id of the device associated with the import. (Deprecated; ignored.)
         :param import_id: The id of the import to delete.
         """
+        if device_id is not None:
+            warnings.warn(
+                "The `device_id` parameter is deprecated.", DeprecationWarning
+            )
         response = requests.delete(
             self.__url__(f"/v1/data/imports/{import_id}"),
             headers=self.__headers,

--- a/foxglove_data_platform/client.py
+++ b/foxglove_data_platform/client.py
@@ -6,6 +6,7 @@ from io import BytesIO
 import json
 from typing import IO, Any, Dict, List, Optional, TypeVar, Union
 import base64
+import warnings
 
 import arrow
 import requests
@@ -165,6 +166,11 @@ def _download_stream_with_progress(
 
 class Client:
     def __init__(self, token: str, host: str = "api.foxglove.dev"):
+        warnings.warn(
+            "The `foxglove_data_platform` package has been renamed to `foxglove`."
+            + " Please migrate to `foxglove` to receive future updates.",
+            DeprecationWarning,
+        )
         self.__token = token
         self.__headers = {
             "Content-type": "application/json",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.14.1
+version = 0.14.2
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.14.0
+version = 0.14.1
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
### Changelog

The `foxglove-data-platform` package has been renamed to `foxglove-client`. Please migrate to `foxglove-client` to receive future updates.

### Docs

https://github.com/foxglove/docs/pull/271

### Description

Also added logging of existing deprecations ~which will be removed in #105~ – decided not to do this for now, but we can still add the warnings.