### PR TITLE
Bump version to 0.14.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-data-platform
-version = 0.14.0
+version = 0.14.1
 description = Client library for Foxglove Data Platform.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
### Changelog
Releasing changes from https://github.com/foxglove/py-data-platform/pull/103 & #98

### Docs

None

### Description

0.14.0 was never actually published. Bumping to 0.14.1 to try and fix CI.